### PR TITLE
feat(checkout): CHECKOUT-9161 Feature Request - Support multiple ship…

### DIFF
--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -17,6 +17,7 @@ interface ConsignmentAddressSelectorProps {
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;
+    isGuest: boolean;
     onUnhandledError(error: Error): void;
     setConsignmentRequest?(consignmentRequest: ConsignmentCreateRequestBody): void;
     selectedAddress?: Address;
@@ -27,6 +28,7 @@ const ConsignmentAddressSelector = ({
     countriesWithAutocomplete,
     defaultCountryCode,
     isLoading,
+    isGuest,
     onUnhandledError,
     selectedAddress,
     setConsignmentRequest,
@@ -122,11 +124,14 @@ const ConsignmentAddressSelector = ({
 
         await handleSelectAddress(address);
 
-        try {
-            await createCustomerAddress(address);
-        } catch (error) {
-            if (error instanceof Error) {
-                setCreateCustomerAddressError(error);
+        if(!isGuest)
+        {
+            try {
+                await createCustomerAddress(address);
+            } catch (error) {
+                if (error instanceof Error) {
+                    setCreateCustomerAddressError(error);
+                }
             }
         }
 

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -11,6 +11,7 @@ import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import { MultiShippingConsignmentData } from "./MultishippingType";
 import { setRecommendedOrMissingShippingOption } from './utils';
+import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 
 interface ConsignmentAddressSelectorProps {
     consignment?: MultiShippingConsignmentData;
@@ -167,6 +168,7 @@ const ConsignmentAddressSelector = ({
                 onRequestClose={handleCloseAddAddressForm}
                 onSaveAddress={handleSaveAddress}
             />
+            {(!isGuest || selectedAddress) && (
             <AddressSelect
                 addresses={addresses}
                 onSelectAddress={handleSelectAddress}
@@ -175,7 +177,16 @@ const ConsignmentAddressSelector = ({
                 selectedAddress={selectedAddress}
                 showSingleLineAddress
                 type={AddressType.Shipping}
-            />
+            />)}
+            {(isGuest && !selectedAddress) && (
+                 <a
+                                data-test="add-new-address"
+                                href="#"
+                                onClick={preventDefault(() => handleUseNewAddress())}
+                            >
+                                <TranslatedString id="address.enter_address_action" />
+                </a>
+            )}
         </>
     )
 }

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -18,6 +18,7 @@ export interface ConsignmentListItemProps {
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;
+    isGuest: boolean;
     shippingQuoteFailedMessage: string;
     onUnhandledError(error: Error): void;
     resetErrorConsignmentNumber(): void;
@@ -29,6 +30,7 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
     countriesWithAutocomplete,
     defaultCountryCode,
     isLoading,
+    isGuest,
     shippingQuoteFailedMessage,
     onUnhandledError,
     resetErrorConsignmentNumber,
@@ -63,6 +65,7 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
                 isLoading={isLoading}
                 onUnhandledError={onUnhandledError}
                 selectedAddress={consignment.shippingAddress}
+                isGuest={isGuest}
             />
             <ConsignmentLineItem
                 consignment={consignment}

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -29,12 +29,15 @@ export interface MultiShippingFormProps {
     isLoading: boolean;
     onUnhandledError(error: Error): void;
     onSubmit(values: MultiShippingFormValues): void;
+    isGuest: boolean;
+
 }
 
 const MultiShippingForm: FunctionComponent<MultiShippingFormProps> = ({
     countriesWithAutocomplete,
     defaultCountryCode,
     isLoading,
+    isGuest,
     onUnhandledError,
     cartHasChanged,
 }: MultiShippingFormProps) => {
@@ -118,6 +121,7 @@ const MultiShippingForm: FunctionComponent<MultiShippingFormProps> = ({
                     countriesWithAutocomplete={countriesWithAutocomplete}
                     defaultCountryCode={defaultCountryCode}
                     isLoading={isLoading}
+                    isGuest={isGuest}
                     key={consignment.id}
                     onUnhandledError={onUnhandledError}
                     resetErrorConsignmentNumber={resetErrorConsignmentNumber}
@@ -130,6 +134,7 @@ const MultiShippingForm: FunctionComponent<MultiShippingFormProps> = ({
                     countriesWithAutocomplete={countriesWithAutocomplete}
                     defaultCountryCode={defaultCountryCode}
                     isLoading={isLoading}
+                    isGuest={isGuest}
                     onUnhandledError={onUnhandledError}
                     resetErrorConsignmentNumber={resetErrorConsignmentNumber}
                     setIsAddShippingDestination={setIsAddShippingDestination}

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -19,6 +19,7 @@ interface NewConsignmentProps {
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;
+    isGuest: boolean;
     setIsAddShippingDestination: React.Dispatch<React.SetStateAction<boolean>>;
     onUnhandledError(error: Error): void;
     resetErrorConsignmentNumber(): void;
@@ -29,6 +30,7 @@ const NewConsignment = ({
     countriesWithAutocomplete,
     defaultCountryCode,
     isLoading,
+    isGuest,
     onUnhandledError,
     resetErrorConsignmentNumber,
     setIsAddShippingDestination,
@@ -109,6 +111,7 @@ const NewConsignment = ({
                 countriesWithAutocomplete={countriesWithAutocomplete}
                 defaultCountryCode={defaultCountryCode}
                 isLoading={isLoading}
+                isGuest={isGuest}
                 onUnhandledError={onUnhandledError}
                 selectedAddress={selectedAddress}
                 setConsignmentRequest={setConsignmentRequest}

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -17,7 +17,6 @@ import { useExtensions } from '@bigcommerce/checkout/checkout-extension';
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
-import MultiShippingGuestForm from './MultiShippingGuestForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
 
 export interface ShippingFormProps {
@@ -61,7 +60,6 @@ const ShippingForm = ({
       consignments,
       countries,
       countriesWithAutocomplete,
-      onCreateAccount,
       customerMessage,
       deinitialize,
       deleteConsignments,
@@ -74,7 +72,6 @@ const ShippingForm = ({
       isMultiShippingMode,
       methodId,
       onMultiShippingSubmit,
-      onSignIn,
       onSingleShippingSubmit,
     onUnhandledError,
       shippingAddress,
@@ -92,11 +89,12 @@ const ShippingForm = ({
     } = useExtensions();
 
     const getMultiShippingForm = () => {
-        if (isGuest) {
-            return (
-                <MultiShippingGuestForm onCreateAccount={onCreateAccount} onSignIn={onSignIn} />
-            );
-        }
+        // if (isGuest) {
+        //     return (
+        //         <MultiShippingGuestForm onCreateAccount={onCreateAccount} onSignIn={onSignIn} />
+        //     );
+        // }
+
 
         return <MultiShippingForm
             cartHasChanged={cartHasChanged}
@@ -104,6 +102,7 @@ const ShippingForm = ({
             customerMessage={customerMessage}
             defaultCountryCode={shippingAddress?.countryCode}
             isLoading={isLoading}
+            isGuest={isGuest}
             onSubmit={onMultiShippingSubmit}
             onUnhandledError={onUnhandledError}
         />;


### PR DESCRIPTION
ping addresses for guest users

feat(checkout): CHECKOUT-9161 Feature Request - Support multiple shipping addresses for guest users

## What?
As a guest customer purchasing on the site,

I want to be able to add multiple shipping addresses during checkout

So that I can get items shipped to different addresses.

## Why?
This brings feature parity between guest and registered users thus removing friction at checkout.

## Testing / Proof

Added multiple consignments with guest checkout:

<img width="737" alt="Screenshot 2025-04-18 at 00 37 23" src="https://github.com/user-attachments/assets/b14fb461-2600-40fa-8116-2cdd29e462c2" />

Registered user flow works as is: 
<img width="702" alt="image" src="https://github.com/user-attachments/assets/0bbefa7c-2e39-4082-841e-46e56c7fae92" />


@bigcommerce/team-checkout
